### PR TITLE
chore: implement bundler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,46 @@ Add a feature to your gem as follows:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake
-spec` to run the tests. You can also run `bin/console` for an interactive prompt that
-will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake` to run all the tests that will be run in the `continuous-integration`
+workflow. You can also run `bin/console` for an interactive prompt that will allow
+you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To
 release a new version, update the version number in `version.rb`, and then run
 `bundle exec rake release`, which will create a git tag for the version, push git
 commits and the created tag, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
+
+To install this bundler plugin from the source code, run the following command from
+the project's root directory:
+
+```shell
+bundler plugin install --path . bundler-gem_bytes
+```
+
+and then run `bundler plugin list` to make sure it was installed correctly:
+
+```shell
+$ bundler plugin list
+bundler-gem_bytes
+-----
+  gem-bytes
+
+$
+```
+
+Once installed, the bundler plugin can be run with the following command:
+
+```shell
+bundler gem-bytes
+```
+
+To uninstall the plugin, run:
+
+```shell
+bundler uninstall bundler-gem_bytes
+```
 
 ## Contributing
 

--- a/lib/bundler/gem_bytes.rb
+++ b/lib/bundler/gem_bytes.rb
@@ -10,12 +10,8 @@ module Bundler
   # @api public
   #
   module GemBytes
-    # Base error class for this gem
-    #
-    # @api public
-    #
-    class Error < StandardError; end
   end
-
-  require_relative 'gem_bytes/version'
 end
+
+require_relative 'gem_bytes/bundler_command'
+require_relative 'gem_bytes/version'

--- a/lib/bundler/gem_bytes/bundler_command.rb
+++ b/lib/bundler/gem_bytes/bundler_command.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Bundler
+  module GemBytes
+    # A bundler command that adds features to your existing Ruby Gems project
+    #
+    # See [our repository of templates](http://gembytes.com/templates) for adding
+    # testing, linting, and security frameworks to your project.
+    #
+    # @api public
+    #
+    class BundlerCommand < Bundler::Plugin::API
+      # Called when the `gem-bytes` command is invoked
+      #
+      # @example
+      #   $ bundler gem-bytes
+      #
+      # @param command [String] the command that was invoked (in this case, 'gem-bytes')
+      # @param args [Array<String>] any additional arguments passed to the command
+      #
+      # @raise [BundlerError] if there was an error executing the command
+      # @return [void]
+      #
+      def exec(command, args)
+        puts 'Hello from the gem-bytes bundler command'
+        puts "You called #{command} with args: #{args.inspect}"
+      end
+    end
+  end
+end

--- a/plugins.rb
+++ b/plugins.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_bytes'
+
+# Register Bundler::GemBytes::BundlerCommand as the handler for the `gem-bytes`
+# bundler command
+
+Bundler::Plugin::API.command('gem-bytes', Bundler::GemBytes::BundlerCommand)

--- a/spec/lib/bundler/gem_bytes/bundler_command_spec.rb
+++ b/spec/lib/bundler/gem_bytes/bundler_command_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::GemBytes::BundlerCommand do
+  let(:instance) { described_class.new }
+
+  describe '#exec' do
+    subject { instance.exec(command, args) }
+    context "when called with 'gem-bytes', 'a', 'b'" do
+      let(:command) { 'gem-bytes' }
+      let(:args) { %w[a b] }
+      it 'should output a hello world message' do
+        expected_output = <<~OUTPUT
+          Hello from the gem-bytes bundler command
+          You called gem-bytes with args: ["a", "b"]
+        OUTPUT
+        expect { subject }.to output(expected_output).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
Turn this gem project into a simple bundler plugin named 'gem-bytes' that (for
now) just outputs a 'hello world' message.
_
Install the bundler plugin from the root project directory with the following
command:
```shell
bundler plugin install --path . bundler-gem_bytes
```
_
Verify the installation with:
```shell
bundler plugin list
```
_
Run the plugin (which just prints a "hello world" message) as follows:
```shell
bundler gem-bytes
```
You can also give additional arguments which will be included in the message
output:
```shell
bundler gem-bytes arg1 arg2
```
_
Uninstall the plugin with
```shell
bundler plugin uninstall bundler-gem_bytes
```