### PR TITLE
Add script loading to the bundler gem-bytes plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # bundler-gem_bytes gem
 
-[![Gem Version](https://badge.fury.io/rb/bundler-gem_bytes.svg)](https://badge.fury.io/rb/bundler-gem_bytes)
+[![Gem
+Version](https://badge.fury.io/rb/bundler-gem_bytes.svg)](https://badge.fury.io/rb/bundler-gem_bytes)
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/bundler-gem_bytes/)
-[![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/bundler-gem_bytes/file/CHANGELOG.md)
-[![Build Status](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml)
+[![Change
+Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/bundler-gem_bytes/file/CHANGELOG.md)
+[![Build
+Status](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2468fc247e5d66fc179f/maintainability)](https://codeclimate.com/github/main-branch/bundler-gem_bytes/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2468fc247e5d66fc179f/test_coverage)](https://codeclimate.com/github/main-branch/bundler-gem_bytes/test_coverage)
+[![Test
+Coverage](https://api.codeclimate.com/v1/badges/2468fc247e5d66fc179f/test_coverage)](https://codeclimate.com/github/main-branch/bundler-gem_bytes/test_coverage)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Slack](https://img.shields.io/badge/slack-main--branch/bundler--gem_bytes-yellow.svg?logo=slack)](https://main-branch.slack.com/archives/C07RKRKTLDT)
 
-**NOTE: https://gembytes.com is not yet active. For now, you will have to bring your own URL.**
+**NOTE: https://gembytes.com is not yet active. For now, you will have to bring your
+own URL.**
 
 A bundler plugin that adds features to your existing Ruby Gems project.
 
@@ -19,6 +24,8 @@ linting, and security frameworks to your project.
 
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Example](#example)
+  * [Handling Errors](#handling-errors)
 * [Development](#development)
 * [Contributing](#contributing)
   * [Commit message guidelines](#commit-message-guidelines)
@@ -42,12 +49,23 @@ gem install bundler-gem_bytes
 
 ## Usage
 
-Add a feature to your gem as follows:
+The `bundler gem-bytes` command requires exactly one argument, which can either be a
+file path or a URI to a script. The script will be loaded and executed within the
+context of your project.
 
-1. Find a feature to add at http://gembytes.com/features and make a note of the
-   feature URL
-2. Run `bundle gem-bytes URL`
-3. Test the changes made to your project.
+### Example
+
+1. Find a script or feature template you'd like to add to your gem and make a note of
+   its URL.
+2. Run `bundler gem-bytes URL_OR_PATH` where `URL_OR_PATH` is either a local file
+   path or a remote URI.
+3. The script will be executed, and the relevant feature will be applied to your
+   project.
+
+### Handling Errors
+
+If the file or URI cannot be loaded, an error message will be printed to `stderr`,
+and the command will exit with a status code of `1`.
 
 ## Development
 
@@ -132,6 +150,6 @@ License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the Bundler::GemBytes project's codebases, issue trackers, chat
-rooms and mailing lists is expected to follow the [code of
+Everyone interacting in the Bundler::GemBytes project's codebases, issue trackers,
+chat rooms and mailing lists is expected to follow the [code of
 conduct](https://github.com/main-branch/bundler-gem_bytes/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/bundler/gem_bytes/bundler_command.rb
+++ b/lib/bundler/gem_bytes/bundler_command.rb
@@ -13,7 +13,7 @@ module Bundler
       # Called when the `gem-bytes` command is invoked
       #
       # @example
-      #   $ bundler gem-bytes
+      #   $ bundler gem-bytes URI_OR_PATH
       #
       # @param command [String] the command that was invoked (in this case, 'gem-bytes')
       # @param args [Array<String>] any additional arguments passed to the command
@@ -21,9 +21,40 @@ module Bundler
       # @raise [BundlerError] if there was an error executing the command
       # @return [void]
       #
-      def exec(command, args)
-        puts 'Hello from the gem-bytes bundler command'
-        puts "You called #{command} with args: #{args.inspect}"
+      def exec(_command, args)
+        uri_or_path = validate_args(args)
+        script_content = load_script(uri_or_path)
+        puts script_content
+      end
+
+      private
+
+      # Validates that exactly one argument is provided
+      #
+      # @param args [Array<String>] the arguments passed to the command
+      # @raise [SystemExit] if the argument count is not correct
+      # @return [String] the validated URI or file path
+      # @api private
+      def validate_args(args)
+        if args.size != 1
+          warn 'Error: You must provide exactly one argument, either a file path or URI.'
+          exit 1
+        end
+        args.first
+      end
+
+      # Loads the script content from the provided URI or file path
+      #
+      # @param uri_or_path [String] the URI or file path to load the script from
+      # @raise [SystemExit] if there is an error loading the script
+      # @return [String] the content of the script
+      # @api private
+      def load_script(uri_or_path)
+        loader = ScriptLoader.new(uri_or_path)
+        loader.load
+      rescue RuntimeError => e
+        warn "Error loading script: #{e.message}"
+        exit 1
       end
     end
   end

--- a/spec/lib/bundler/gem_bytes/bundler_command_spec.rb
+++ b/spec/lib/bundler/gem_bytes/bundler_command_spec.rb
@@ -2,18 +2,56 @@
 
 RSpec.describe Bundler::GemBytes::BundlerCommand do
   let(:instance) { described_class.new }
+  let(:loader) { instance_double(Bundler::GemBytes::ScriptLoader) }
+
+  before do
+    allow(Bundler::GemBytes::ScriptLoader).to receive(:new).and_return(loader)
+  end
 
   describe '#exec' do
     subject { instance.exec(command, args) }
-    context "when called with 'gem-bytes', 'a', 'b'" do
-      let(:command) { 'gem-bytes' }
-      let(:args) { %w[a b] }
-      it 'should output a hello world message' do
-        expected_output = <<~OUTPUT
-          Hello from the gem-bytes bundler command
-          You called gem-bytes with args: ["a", "b"]
-        OUTPUT
-        expect { subject }.to output(expected_output).to_stdout
+    let(:command) { 'gem-bytes' }
+
+    context 'when no arguments are passed' do
+      let(:args) { [] }
+
+      it 'outputs an error to stderr and exits' do
+        expect { subject }.to(
+          output(/Error: You must provide exactly one argument/).to_stderr
+          .and(raise_error(SystemExit))
+        )
+      end
+    end
+
+    context 'when more than one argument is passed' do
+      let(:args) { %w[file1 file2] }
+
+      it 'outputs an error to stderr and exits' do
+        expect { subject }.to(
+          output(/Error: You must provide exactly one argument/).to_stderr
+          .and(raise_error(SystemExit))
+        )
+      end
+    end
+
+    context 'when a valid script path is passed' do
+      let(:args) { ['valid_script.rb'] }
+
+      it 'outputs the content of the script to stdout' do
+        allow(loader).to receive(:load).and_return('script content')
+        expect { subject }.to output("script content\n").to_stdout
+      end
+    end
+
+    context 'when an error occurs loading the script' do
+      let(:args) { ['invalid_script.rb'] }
+
+      it 'outputs an error message to stderr and exits' do
+        allow(loader).to receive(:load).and_raise(RuntimeError.new('File not found'))
+        expect { subject }.to(
+          output(/Error loading script: File not found/).to_stderr
+          .and(raise_error(SystemExit))
+        )
       end
     end
   end


### PR DESCRIPTION
Change Bundler::GemBytes::BundleCommand so the plugin
accepts only one argument: a string that can be either a path
to a local script file or a URI reference to a script.