### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,17 @@ All notable changes to the process_executer gem will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.1.0 (2024-10-17)
+
+[Full Changelog](https://github.com/main-branch/bundler-gem_bytes/compare/ce13f25..v0.1.0)
+
+Changes:
+
+* b678393 feat: download and execute GemBytes script
+* 88c3ee9 chore: add script loading to the bundler plugin
+* afda321 chore: add bug tracker uri to gemspec
+* fe40e6c feat: add the script loader class
+* 83c8841 fix: correct the require for bindler/gem_bytes in bin/console
+* 74a638a chore: implement bundler plugin
+* ce13f25 chore: initial version


### PR DESCRIPTION
# Release PR

## v0.1.0 (2024-10-17)

[Full Changelog](https://github.com/main-branch/bundler-gem_bytes/compare/ce13f25..v0.1.0)

Changes:

* b678393 feat: download and execute GemBytes script
* 88c3ee9 chore: add script loading to the bundler plugin
* afda321 chore: add bug tracker uri to gemspec
* fe40e6c feat: add the script loader class
* 83c8841 fix: correct the require for bindler/gem_bytes in bin/console
* 74a638a chore: implement bundler plugin
* ce13f25 chore: initial version
