### PR TITLE
Make it easy for a gembytes script to add a dependency in the project gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,34 +85,32 @@ release a new version, update the version number in `version.rb`, and then run
 commits and the created tag, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 
-To install this bundler plugin from the source code, run the following command from
-the project's root directory:
+To debug this gem it is recommended that you create a test project and install
+this plugin with bundler from source code as follows:
 
 ```shell
-bundler plugin install --path . bundler-gem_bytes
-```
+# 1. Create a temp directory for testing (from the root directory of the project)
+mkdir temp
+cd temp
 
-and then run `bundler plugin list` to make sure it was installed correctly:
+# 2. Create an new, empty RubyGem project to test
+BUNDLE_IGNORE_CONFIG=TRUE bundle gem foo --no-test --no-ci --no-mit --no-coc --no-linter --no-changelog
+cd foo
 
-```shell
-$ bundler plugin list
-bundler-gem_bytes
------
-  gem-bytes
+# 3. Install the plugin from source
+BUNDLE_IGNORE_CONFIG=TRUE bundle plugin install --path ../.. bundler-gem_bytes
 
-$
-```
+# 4. Create a gembytes script to add a development dependency on rubocop
+cat <<SCRIPT > gem_bytes_script.rb
+add_dependency :development, "rubocop", "~> 1.6"
+SCRIPT
 
-Once installed, the bundler plugin can be run with the following command:
+# 5. Modify code, set breakpoints, or add binding.{irb|pry} calls to the source
 
-```shell
-bundler gem-bytes
-```
+# 6. Run the plugin
+BUNDLE_IGNORE_CONFIG=TRUE bundle gem-bytes gem_bytes_script.rb
 
-To uninstall the plugin, run:
-
-```shell
-bundler uninstall bundler-gem_bytes
+# Repeat 4 - 6 until satisified :)
 ```
 
 ## Contributing

--- a/bundler-gem_bytes.gemspec
+++ b/bundler-gem_bytes.gemspec
@@ -44,6 +44,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'parser', '~> 3.3'
+  spec.add_dependency 'rubocop-ast', '~> 1.32'
   spec.add_dependency 'thor', '~> 1.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'

--- a/bundler-gem_bytes.gemspec
+++ b/bundler-gem_bytes.gemspec
@@ -51,11 +51,14 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'main_branch_shared_rubocop_config'
+  spec.add_development_dependency 'process_executer', '~> 1.2'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'simplecov-rspec', '~> 0.4'
+  spec.add_development_dependency 'turnip', '~> 4.4'
 
   if RUBY_PLATFORM != 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.5'

--- a/lib/bundler/gem_bytes.rb
+++ b/lib/bundler/gem_bytes.rb
@@ -14,6 +14,7 @@ module Bundler
 end
 
 require 'active_support'
+require 'thor'
 
 require_relative 'gem_bytes/bundler_command'
 require_relative 'gem_bytes/gemspec'

--- a/lib/bundler/gem_bytes.rb
+++ b/lib/bundler/gem_bytes.rb
@@ -13,6 +13,9 @@ module Bundler
   end
 end
 
+require 'active_support'
+
 require_relative 'gem_bytes/bundler_command'
+require_relative 'gem_bytes/gemspec'
 require_relative 'gem_bytes/script_executor'
 require_relative 'gem_bytes/version'

--- a/lib/bundler/gem_bytes/actions.rb
+++ b/lib/bundler/gem_bytes/actions.rb
@@ -1,9 +1,37 @@
 # frozen_string_literal: true
 
+require 'bundler/gem_bytes'
+
 module Bundler
   module GemBytes
     # The API for GemBytes templates
     # @api public
-    module Actions; end
+    module Actions
+      # Adds (or updates) a dependency in the project's gemspec file
+      #
+      # @example
+      #   add_dependency(:development, 'rspec', '~> 3.13')
+      #   add_dependency(:runtime, 'activesupport', '>= 6.0.0')
+      #
+      # @param dependency_type [Symbol] the type of dependency to add (either :development or :runtime)
+      # @param gem_name [String] the name of the gem to add
+      # @param version_constraint [String] the version constraint for the gem
+      # @param force [Boolean] whether to overwrite the existing dependency
+      # @param gemspec [String] the path to the gemspec file
+      #
+      # @return [void]
+      #
+      # @api public
+      #
+      def add_dependency(dependency_type, gem_name, version_constraint, force: false, gemspec: Dir['*.gemspec'].first)
+        puts 'Staring'
+        source = File.read(gemspec)
+        updated_source = Bundler::GemBytes::Gemspec::UpsertDependency.new(
+          dependency_type, gem_name, version_constraint, force: force
+        ).call(source)
+        File.write(gemspec, updated_source)
+        puts 'Ending'
+      end
+    end
   end
 end

--- a/lib/bundler/gem_bytes/actions.rb
+++ b/lib/bundler/gem_bytes/actions.rb
@@ -24,13 +24,11 @@ module Bundler
       # @api public
       #
       def add_dependency(dependency_type, gem_name, version_constraint, force: false, gemspec: Dir['*.gemspec'].first)
-        puts 'Staring'
         source = File.read(gemspec)
         updated_source = Bundler::GemBytes::Gemspec::UpsertDependency.new(
           dependency_type, gem_name, version_constraint, force: force
         ).call(source)
         File.write(gemspec, updated_source)
-        puts 'Ending'
       end
     end
   end

--- a/lib/bundler/gem_bytes/actions.rb
+++ b/lib/bundler/gem_bytes/actions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Bundler
+  module GemBytes
+    # The API for GemBytes templates
+    # @api public
+    module Actions; end
+  end
+end

--- a/lib/bundler/gem_bytes/actions.rb
+++ b/lib/bundler/gem_bytes/actions.rb
@@ -27,7 +27,7 @@ module Bundler
         source = File.read(gemspec)
         updated_source = Bundler::GemBytes::Gemspec::UpsertDependency.new(
           dependency_type, gem_name, version_constraint, force: force
-        ).call(source)
+        ).call(source, path: gemspec)
         File.write(gemspec, updated_source)
       end
     end

--- a/lib/bundler/gem_bytes/bundler_command.rb
+++ b/lib/bundler/gem_bytes/bundler_command.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 module Bundler
   module GemBytes
     # A bundler command that adds features to your existing Ruby Gems project

--- a/lib/bundler/gem_bytes/gemspec.rb
+++ b/lib/bundler/gem_bytes/gemspec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Bundler
+  module GemBytes
+    # The namespec for classes that modify the gemspec file
+    module Gemspec; end
+  end
+end
+
+require_relative 'gemspec/upsert_dependency'

--- a/lib/bundler/gem_bytes/gemspec/upsert_dependency.rb
+++ b/lib/bundler/gem_bytes/gemspec/upsert_dependency.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'parser/current'
+require 'rubocop-ast'
+require 'active_support/core_ext/object'
+
+module Bundler
+  module GemBytes
+    module Gemspec
+      # Add or update a dependency in a gemspec file
+      #
+      # This class allows the addition of a new dependency or the updating of an
+      # existing dependency in a gemspec file.
+      #
+      # This class works by parsing the gemspec file into an AST and then walking the
+      # AST to find the Gem::Specification block (via #on_block). Once the block is
+      # found, AST within that block is walked to locate the dependency declarations
+      # (via #on_send). Any dependency declaration that matches the given gem name is
+      # collected into the found_dependencies array.
+      #
+      # Once the Gem::Specification block is fully processed, if a dependency on the
+      # given gem is not found, a new dependency is added to the end of the
+      # Gem::Specification block.
+      #
+      # If one or more dependencies are found, the version constraint is updated to
+      # the given version constraint. If the dependency type is different from the
+      # existing dependency, an error is raised unless the `force` option is set to
+      # true.
+      #
+      # @example
+      #   require 'bundler/gem_bytes'
+      #
+      #   add_dependency = Bundler::GemBytes::Gemspec::UpsertDependency.new(:dependency, 'test_tool', '~> 2.1')
+      #
+      #   gemspec = File.read('bundler-gem_bytes.gemspec')
+      #   updated_gemspec = add_dependency.call(gemspec)
+      #   File.write('project.gemspec', updated_gemspec)
+      #
+      # @!attribute [r] dependency_type
+      #   The type of dependency to add
+      #   @return [:runtime, :depenncy]
+      #   @api private
+      #
+      # @!attribute [r] gem_name
+      #   The name of the gem to add a dependency on (i.e. 'rubocop')
+      #   @return [String]
+      #   @api private
+      #
+      # @!attribute [r] version_constraint
+      #   The version constraint for the gem (i.e. '~> 2.1')
+      #   @return [String]
+      #   @api private
+      #
+      # @!attribute [r] force
+      #   Whether to update the dependency even if the type is different
+      #   @return [Boolean]
+      #   @api private
+      #
+      # @!attribute [r] receiver_name
+      #   The name of the receiver for the Gem::Specification block
+      #
+      #    i.e. 'spec' in `spec.add_dependency 'rubocop', '~> 1.0'`
+      #
+      #   @return [Symbol]
+      #   @api private
+      #
+      # @!attribute [r] found_gemspec_block
+      #   Whether the Gem::Specification block was found in the gemspec file
+      #
+      #   Only valid after calling `#call`.
+      #   @return [Boolean]
+      #   @api private
+      #
+      # @!attribute [r] found_dependencies
+      #   The dependencies found in the gemspec file
+      #
+      #   Only valid after calling `#call`.
+      #   @return [Array<Hash>]
+      #   @api private
+      #
+      # @api public
+      class UpsertDependency < Parser::TreeRewriter # rubocop:disable Metrics/ClassLength
+        # Create a new instance of a dependency upserter
+        # @example
+        #   add_dependency = Bundler::GemBytes::Gemspec::UpsertDependency.new(:runtime, 'my_gem', '~> 1.0')
+        # @param dependency_type [Symbol] The type of dependency to add
+        # @param gem_name [String] The name of the gem to add a dependency on
+        # @param version_constraint [String] The version constraint for the gem
+        # @param force [Boolean] Whether to update the dependency even if the type is different
+        def initialize(dependency_type, gem_name, version_constraint, force: false)
+          super()
+
+          self.dependency_type = dependency_type
+          @gem_name = gem_name
+          self.version_constraint = version_constraint
+          @force = force
+
+          @found_dependencies = []
+        end
+
+        # Returns the content of the gemspec file with the new/updated dependency
+        #
+        # @param code [String] The content of the gemspec file
+        #
+        # @return [String] The updated gemspec content with the new/added dependency
+        #
+        # @raise [ArgumentError] if the Gem Specification block is not found in the given gemspec
+        #
+        # @example
+        #   code = File.read('project.gemspec')
+        #   add_dependency = Bundler::GemBytes::AddDependency.new(:runtime, 'my_gem', '~> 1.0')
+        #   updated_code = add_dependency.call(code)
+        #   puts updated_code
+        #
+        #
+        def call(code)
+          ast = RuboCop::AST::ProcessedSource.new(code, ruby_version).ast
+          buffer = Parser::Source::Buffer.new('(string)', source: code)
+          @found_gemspec_block = false
+          rewrite(buffer, ast).tap do |_result|
+            raise ArgumentError, 'Gem::Specification block not found' unless found_gemspec_block
+          end
+        end
+
+        attr_reader :dependency_type, :gem_name, :version_constraint, :force,
+                    :receiver_name, :found_gemspec_block, :found_dependencies
+
+        # Handles block nodes within the AST to locate the Gem Specification block
+        #
+        # @param node [Parser::AST::Node] The block node within the AST
+        # @return [void]
+        # @api private
+        def on_block(node)
+          return if receiver_name # already processing the Gem Specification block
+
+          @found_gemspec_block = true
+          @receiver_name = gem_specification_pattern.match(node)
+
+          return unless receiver_name
+
+          super # process the children of this node to find the existing dependencies
+
+          upsert_dependency(node)
+
+          @receiver_name = nil
+        end
+
+        # Handles `send` nodes within the AST to locate dependency calls
+        #
+        # If receiver_name is not present then we are not in a Gem Specification block.
+        #
+        # @param node [Parser::AST::Node] The `send` node to check for dependency patterns
+        # @return [void]
+        # @api private
+        def on_send(node)
+          return unless receiver_name.present?
+          return unless (match = dependency_pattern.match(node))
+
+          found_dependencies << { node:, match: }
+        end
+
+        private
+
+        # Adds or updates the given dependency in the Gem::Specification block
+        # @param node [Parser::AST::Node] The block node within the AST
+        # @return [void]
+        # @api private
+        def upsert_dependency(node)
+          if found_dependencies.empty?
+            add_dependency(node)
+          else
+            update_dependency
+          end
+        end
+
+        # Adds a new dependency to the Gem::Specification block
+        # @param node [Parser::AST::Node] The Gem::Specification block node within the AST
+        # @return [void]
+        # @api private
+        def add_dependency(node)
+          insert_after(node.children[2].children.last.loc.expression, "\n  #{dependency_source_code}")
+        end
+
+        # The dependency type (:runtime or :development) based on a given method name
+        # @param method [Symbol] The method name to convert to a dependency type
+        # @return [Symbol] The dependency type
+        # @api private
+        def dependency_method_to_type(method)
+          method == :add_development_dependency ? :development : :runtime
+        end
+
+        # Error message for a dependency type conflict
+        # @param node [Parser::AST::Node] The existing dependency node
+        # @return [String] The error message
+        # @api private
+        def dependency_type_conflict_error(node)
+          <<~MESSAGE.chomp.gsub("\n", ' ')
+            Trying to add a
+            #{dependency_method_to_type(dependency_type_method).upcase}
+            dependency on "#{gem_name}" which conflicts with the existing
+            #{dependency_method_to_type(node.children[1]).upcase}
+            dependency.
+            Pass force: true to update dependencies where the
+            dependency type is different.
+          MESSAGE
+        end
+
+        # Checks if the given dependency type conflicts with the existing dependency type
+        #
+        # Returns false if {#force} is true.
+        #
+        # @param dependency_node [Parser::AST::Node] The existing dependency node
+        # @return [Boolean] Whether the dependency type conflicts
+        # @api private
+        def dependency_type_conflict?(dependency_node)
+          dependency_node.children[1] != dependency_type_method && !force
+        end
+
+        # The source code for the updated dependency declaration
+        # @param existing_dependency_node [Parser::AST::Node] The existing dependency node
+        # @return [String] The source code for the dependency declaration
+        # @api private
+        def dependency_source_code(existing_dependency_node = nil)
+          # Use existing quote character for string literals
+          q = existing_dependency_node ? existing_dependency_node.children[3].loc.expression.source[0] : "'"
+          "#{receiver_name}.#{dependency_type_method} #{q}#{gem_name}#{q}, #{q}#{version_constraint}#{q}"
+        end
+
+        # Replaces the existing dependency node with the updated dependency declaration
+        # @param dependency_node [Parser::AST::Node] The existing dependency node
+        # @return [void]
+        # @api private
+        def replace_dependency_node(dependency_node)
+          replace(dependency_node.loc.expression, dependency_source_code(dependency_node))
+        end
+
+        # Updates the found_dependencies from the Gem::Specification block
+        # @return [void]
+        # @api private
+        def update_dependency
+          found_dependencies.each do |found_dependency|
+            dependency_node = found_dependency[:node]
+            raise(dependency_type_conflict_error(dependency_node)) if dependency_type_conflict?(dependency_node)
+
+            replace_dependency_node(dependency_node)
+          end
+        end
+
+        # Validates and sets the dependency type
+        # @param dependency_type [Symbol] The type of dependency to add (must be :runtime or :development)
+        # @raise [ArgumentError] if the dependency type is not :runtime or :development
+        # @return [Symbol] The dependency type
+        # @api private
+        def dependency_type=(dependency_type)
+          unless %i[runtime development].include?(dependency_type)
+            raise(
+              ArgumentError,
+              "Invalid dependency type: #{dependency_type.inspect}"
+            )
+          end
+          @dependency_type = dependency_type
+        end
+
+        # Validates and sets the version constraint
+        # @param version_constraint [String] The version constraint to set
+        # @raise [ArgumentError] if the version constraint is invalid
+        # @return [String] The version constraint
+        # @api private
+        def version_constraint=(version_constraint)
+          begin
+            Gem::Requirement.new(version_constraint)
+            true
+          rescue Gem::Requirement::BadRequirementError
+            raise ArgumentError, "Invalid version constraint: #{version_constraint.inspect}"
+          end
+          @version_constraint = version_constraint
+        end
+
+        # Returns the Ruby version in use as a float (MAJOR.MINOR only)
+        # @return [Float] The Ruby version number, e.g., 3.0
+        # @api private
+        def ruby_version = RUBY_VERSION.match(/^(?<version>\d+\.\d+)/)['version'].to_f
+
+        # Determines the dependency method based on the dependency type
+        # @return [Symbol] Either :add_development_dependency or :add_dependency
+        # @api private
+        def dependency_type_method
+          dependency_type == :development ? :add_development_dependency : :add_dependency
+        end
+
+        # The patter to match a dependency declaration in the AST
+        # @return [RuboCop::AST::NodePattern] The dependency pattern
+        # @api private
+        def dependency_pattern
+          @dependency_pattern ||=
+            RuboCop::AST::NodePattern.new(<<~PATTERN)
+              (send
+                { (send _ :#{receiver_name}) | (lvar :#{receiver_name}) }
+                ${ :add_dependency :add_runtime_dependency :add_development_dependency }
+                (str #{gem_name ? "$\"#{gem_name}\"" : '$_gem_name'})
+                <(str $_version_constraint) ...>
+              )
+            PATTERN
+        end
+
+        # The pattern to match the Gem::Specification block in the AST
+        # @return [RuboCop::AST::NodePattern] The Gem::Specification pattern
+        # @api private
+        def gem_specification_pattern
+          @gem_specification_pattern ||=
+            RuboCop::AST::NodePattern.new(<<~PATTERN)
+              (block (send (const (const nil? :Gem) :Specification) :new)(args (arg $_)) ...)
+            PATTERN
+        end
+      end
+    end
+  end
+end

--- a/lib/bundler/gem_bytes/gemspec/upsert_dependency.rb
+++ b/lib/bundler/gem_bytes/gemspec/upsert_dependency.rb
@@ -194,6 +194,7 @@ module Bundler
         # @return [String] The error message
         # @api private
         def dependency_type_conflict_error(node)
+          # :nocov: JRuby give false positive for this line being uncovered by tests
           <<~MESSAGE.chomp.gsub("\n", ' ')
             Trying to add a
             #{dependency_method_to_type(dependency_type_method).upcase}
@@ -203,6 +204,7 @@ module Bundler
             Pass force: true to update dependencies where the
             dependency type is different.
           MESSAGE
+          # :nocov:
         end
 
         # Checks if the given dependency type conflicts with the existing dependency type
@@ -253,10 +255,8 @@ module Bundler
         # @api private
         def dependency_type=(dependency_type)
           unless %i[runtime development].include?(dependency_type)
-            raise(
-              ArgumentError,
-              "Invalid dependency type: #{dependency_type.inspect}"
-            )
+            message = "Invalid dependency type: #{dependency_type.inspect}"
+            raise(ArgumentError, message)
           end
           @dependency_type = dependency_type
         end
@@ -292,6 +292,7 @@ module Bundler
         # @return [RuboCop::AST::NodePattern] The dependency pattern
         # @api private
         def dependency_pattern
+          # :nocov: JRuby give false positive for this line being uncovered by tests
           @dependency_pattern ||=
             RuboCop::AST::NodePattern.new(<<~PATTERN)
               (send
@@ -301,6 +302,7 @@ module Bundler
                 <(str $_version_constraint) ...>
               )
             PATTERN
+          # :nocov:
         end
 
         # The pattern to match the Gem::Specification block in the AST

--- a/lib/bundler/gem_bytes/script_executor.rb
+++ b/lib/bundler/gem_bytes/script_executor.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# require 'pp'
 require 'thor'
-require 'uri'
+require_relative 'actions'
 
 module Bundler
   module GemBytes
@@ -13,8 +12,9 @@ module Bundler
     # @example Executing a script from a file or URI
     #   executor = Bundler::GemBytes::ScriptExecutor.new
     #   executor.execute('path_or_uri_to_script')
-    class ScriptExecutor < Thor::Group
-      include Thor::Actions
+    class ScriptExecutor < ::Thor::Group
+      include ::Thor::Actions
+      include Bundler::GemBytes::Actions
 
       # Set the source paths for Thor to use
       # @return [Array<String>] the source paths

--- a/spec/features/actions_steps.rb
+++ b/spec/features/actions_steps.rb
@@ -32,7 +32,7 @@ def command_err = @command_err
 def command_status = @command_status
 # rubocop:enable Style/TrivialAccessors
 
-def run_command(command, raise_on_fail: true, failure_message: "#{command[0]} failed")
+def run_command(command, raise_on_failure: true, failure_message: "#{command[0]} failed")
   out_buffer = StringIO.new
   out_pipe = ProcessExecuter::MonitoredPipe.new(out_buffer)
   err_buffer = StringIO.new
@@ -43,7 +43,7 @@ def run_command(command, raise_on_fail: true, failure_message: "#{command[0]} fa
     @command_err = err_buffer.string
     @command_status = status
 
-    raise "#{failure_message}: #{command_err}" if raise_on_fail && !command_status.success?
+    raise "#{failure_message}: #{command_err}" if raise_on_failure && !command_status.success?
   end
 end
 
@@ -74,7 +74,7 @@ end
 
 step 'I run :command' do |command|
   Dir.chdir(gem_project_dir) do
-    run_command(command.split, fail_on_error: false)
+    run_command(command.split, raise_on_failure: false)
   end
 end
 

--- a/spec/features/actions_steps.rb
+++ b/spec/features/actions_steps.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# In your Turnip step definitions file
+require 'fileutils'
+require 'process_executer'
+require 'stringio'
+require 'tmpdir'
+
+# Around hook to ensure the temp directory is cleaned up
+RSpec.configure do |config|
+  config.around(:each, type: :feature) do |example|
+    @project_dir = Dir.pwd
+    Dir.mktmpdir do |temp_dir|
+      @temp_dir = temp_dir
+      Dir.chdir(temp_dir) do
+        example.run
+      end
+    end
+  end
+end
+
+# rubocop:disable Style/TrivialAccessors
+def project_dir = @project_dir
+def temp_dir = @temp_dir
+def gem_project_dir = @gem_project_dir
+def gem_bytes_script_name = @gem_bytes_script_name
+def gem_bytes_script_path = @gem_bytes_script_path
+def gemspec_path = @gemspec_path
+def env = { 'BUNDLE_IGNORE_CONFIG' => 'TRUE' }
+def command_out = @command_out
+def command_err = @command_err
+def command_status = @command_status
+# rubocop:enable Style/TrivialAccessors
+
+def run_command(command, raise_on_fail: true, failure_message: "#{command[0]} failed")
+  out_buffer = StringIO.new
+  out_pipe = ProcessExecuter::MonitoredPipe.new(out_buffer)
+  err_buffer = StringIO.new
+  err_pipe = ProcessExecuter::MonitoredPipe.new(err_buffer)
+
+  ProcessExecuter.spawn(env, *command, timeout: 5, out: out_pipe, err: err_pipe).tap do |status|
+    @command_out = out_buffer.string
+    @command_err = err_buffer.string
+    @command_status = status
+
+    raise "#{failure_message}: #{command_err}" if raise_on_fail && !command_status.success?
+  end
+end
+
+step 'a gem project named :gem_name with the bundler-gem_bytes plugin installed' do |gem_name|
+  @gem_project_dir = File.join(temp_dir, gem_name)
+
+  command = [
+    'bundle', 'gem', gem_name, '--no-test', '--no-ci', '--no-mit', '--no-coc', '--no-linter', '--no-changelog'
+  ]
+  run_command(command, failure_message: 'Failed to create gem project')
+
+  Dir.chdir(gem_project_dir) do
+    command = ['bundle', 'plugin', 'install', '--path', project_dir, 'bundler-gem_bytes']
+    run_command(command, failure_message: 'Failed to install plugin')
+  end
+end
+
+step 'the project has a gemspec containing:' do |content|
+  @gemspec_path = File.join(@gem_project_dir, "#{File.basename(gem_project_dir)}.gemspec")
+  File.write gemspec_path, content
+end
+
+step 'a gem-bytes script :gem_bytes_script_name containing:' do |gem_bytes_script_name, content|
+  @gem_bytes_script_name = gem_bytes_script_name
+  @gem_bytes_script_path = File.join(@gem_project_dir, gem_bytes_script_name)
+  File.write gem_bytes_script_path, content
+end
+
+step 'I run :command' do |command|
+  Dir.chdir(gem_project_dir) do
+    run_command(command.split, fail_on_error: false)
+  end
+end
+
+step 'the command should have succeeded' do
+  expect(command_status.success?).to eq(true)
+end
+
+step 'the command should have failed' do
+  expect(command_status.success?).to eq(false)
+end
+
+step 'the gemspec should contain:' do |content|
+  expect(File.read(gemspec_path)).to eq(content)
+end
+
+step 'the command stderr should contain :content' do |content|
+  expect(command_err).to include(content)
+end

--- a/spec/features/add_dependency.feature
+++ b/spec/features/add_dependency.feature
@@ -1,0 +1,70 @@
+Feature: Add or update a dependency to the project's gemspec
+
+  Scenario: Add a dependency
+
+    Given a gem project named "foo" with the bundler-gem_bytes plugin installed
+    And the project has a gemspec containing:
+      """
+      Gem::Specification.new do |spec|
+        spec.name = 'foo'
+        spec.version = '1.0'
+      end
+      """
+    And a gem-bytes script "gem_bytes_script" containing:
+      """
+      add_dependency :runtime, 'foo', '>= 1.0'
+      """
+    When I run "bundle gem-bytes gem_bytes_script"
+    Then the command should have succeeded
+    And the gemspec should contain:
+      """
+      Gem::Specification.new do |spec|
+        spec.name = 'foo'
+        spec.version = '1.0'
+        spec.add_dependency 'foo', '>= 1.0'
+      end
+      """
+
+  Scenario: Update a dependency
+
+    Given a gem project named "foo" with the bundler-gem_bytes plugin installed
+    And the project has a gemspec containing:
+      """
+      Gem::Specification.new do |spec|
+        spec.name = 'foo'
+        spec.version = '1.0'
+        spec.add_dependency 'foo', '>= 0.9'
+      end
+      """
+    And a gem-bytes script "gem_bytes_script" containing:
+      """
+      add_dependency :runtime, 'foo', '>= 1.0'
+      """
+    When I run "bundle gem-bytes gem_bytes_script"
+    Then the command should have succeeded
+    And the gemspec should contain:
+      """
+      Gem::Specification.new do |spec|
+        spec.name = 'foo'
+        spec.version = '1.0'
+        spec.add_dependency 'foo', '>= 1.0'
+      end
+      """
+
+  Scenario: Update a dependency with conflicting dependency type
+    Given a gem project named "foo" with the bundler-gem_bytes plugin installed
+    And the project has a gemspec containing:
+      """
+      Gem::Specification.new do |spec|
+        spec.name = 'foo'
+        spec.version = '1.0'
+        spec.add_runtime_dependency 'foo', '>= 0.9'
+      end
+      """
+    And a gem-bytes script "gem_bytes_script" containing:
+      """
+      add_dependency :runtime, 'foo', '>= 1.0'
+      """
+    When I run "bundle gem-bytes gem_bytes_script"
+    Then the command should have failed
+    And the command stderr should contain "the dependency type is different"

--- a/spec/lib/bundler/gem_bytes/actions_spec.rb
+++ b/spec/lib/bundler/gem_bytes/actions_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::GemBytes::Actions do
+  let(:including_class) do
+    Class.new do
+      include Bundler::GemBytes::Actions
+    end
+  end
+
+  let(:instance) { including_class.new }
+
+  # More detailed tests of add_dependency are in the tests for UpsertDependency
+  # class.
+  #
+  # These tests just make sure that calls to add_dependency are correctly delegated
+  # to the UpsertDependency class.
+  #
+  describe '.add_dependency' do
+    subject { instance.add_dependency(dependency_type, gem_name, version_constraint, force:) }
+
+    let(:dependency_type) { :development }
+    let(:gem_name) { 'rspec' }
+    let(:version_constraint) { '~> 3.13' }
+    let(:force) { false }
+
+    it 'adds the dependency to the gemspec' do
+      # Make a temporary directory to work in
+      Dir.mktmpdir do |temp_dir|
+        Dir.chdir(temp_dir) do
+          # Create a new gemspec file
+          gemspec_file = 'my_gem.gemspec'
+          File.write(gemspec_file, <<~GEMSPEC)
+            Gem::Specification.new do |spec|
+              spec.name = 'my_gem'
+              spec.version = '0.1.0'
+            end
+          GEMSPEC
+
+          # Add the dependency
+          instance.add_dependency(dependency_type, gem_name, version_constraint, force: force)
+
+          # Read the gemspec file
+          gemspec_content = File.read(gemspec_file)
+
+          # Check that the dependency was added
+          expect(gemspec_content).to include("spec.add_development_dependency 'rspec', '~> 3.13'")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
+++ b/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Bundler::GemBytes::Gemspec::UpsertDependency do
 
     context 'with valid arguments' do
       let(:expected_attributes) do
+        # :nocov: JRuby give false positive for this line being uncovered by tests
         {
           dependency_type: :development,
           gem_name: 'test_tool',
@@ -20,6 +21,7 @@ RSpec.describe Bundler::GemBytes::Gemspec::UpsertDependency do
           force: false,
           found_dependencies: []
         }
+        # :nocov:
       end
 
       it { is_expected.to have_attributes(expected_attributes) }

--- a/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
+++ b/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe Bundler::GemBytes::Gemspec::UpsertDependency do
   describe '#call' do
     subject { instance.call(gemspec) }
 
+    context 'when the gemspec is not valid Ruby code' do
+      let(:gemspec) { <<~GEMSPEC }
+        This is not valid Ruby code. Please fix this file to continue.
+      GEMSPEC
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(RuntimeError, /Invalid syntax in \(string\)/)
+      end
+    end
+
     context 'when the gemspec does not contain a Gem::Specification block' do
       let(:gemspec) { <<~GEMSPEC }
         puts 'Hello, world!'

--- a/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
+++ b/spec/lib/bundler/gem_bytes/gemspec/upsert_dependency_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::GemBytes::Gemspec::UpsertDependency do
+  let(:instance) { described_class.new(dependency_type, gem_name, version_constraint, force:) }
+
+  let(:dependency_type) { :development }
+  let(:gem_name) { 'test_tool' }
+  let(:version_constraint) { '~> 2.1' }
+  let(:force) { false }
+
+  describe '#initialize' do
+    subject { instance }
+
+    context 'with valid arguments' do
+      let(:expected_attributes) do
+        {
+          dependency_type: :development,
+          gem_name: 'test_tool',
+          version_constraint: '~> 2.1',
+          force: false,
+          found_dependencies: []
+        }
+      end
+
+      it { is_expected.to have_attributes(expected_attributes) }
+    end
+
+    context 'when force is given as true' do
+      let(:force) { true }
+      let(:expected_attributes) { { force: true } }
+
+      it { is_expected.to have_attributes(expected_attributes) }
+    end
+
+    context 'when dependency_type is invalid' do
+      let(:dependency_type) { :invalid }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError, 'Invalid dependency type: :invalid')
+      end
+    end
+
+    context 'when the version constraint is invalid' do
+      let(:version_constraint) { 'invalid' }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError, 'Invalid version constraint: "invalid"')
+      end
+    end
+  end
+
+  describe '#call' do
+    subject { instance.call(gemspec) }
+
+    context 'when the gemspec does not contain a Gem::Specification block' do
+      let(:gemspec) { <<~GEMSPEC }
+        puts 'Hello, world!'
+      GEMSPEC
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError, 'Gem::Specification block not found')
+      end
+    end
+
+    context 'when the gemspec has no dependencies' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.version = '0.1.0'
+        end
+      GEMSPEC
+
+      it 'is expected to add the dependency' do
+        expect(subject).to eq(<<~GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = 'my_project'
+            spec.version = '0.1.0'
+            spec.add_development_dependency 'test_tool', '~> 2.1'
+          end
+        GEMSPEC
+      end
+    end
+
+    context 'when the gemspec has dependencies but not the given one' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.version = '0.1.0'
+          spec.add_dependency 'another_gem', '~> 1.3'
+        end
+      GEMSPEC
+
+      it 'is expected to add the dependency' do
+        expect(subject).to eq(<<~GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = 'my_project'
+            spec.version = '0.1.0'
+            spec.add_dependency 'another_gem', '~> 1.3'
+            spec.add_development_dependency 'test_tool', '~> 2.1'
+          end
+        GEMSPEC
+      end
+    end
+
+    context 'when the gemspec has the given dependency with the same type and version constraint' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.version = '0.1.0'
+          spec.add_development_dependency 'test_tool', '~> 2.1'
+        end
+      GEMSPEC
+
+      it 'is expected to not change the gemspec' do
+        expect(subject).to eq(gemspec)
+      end
+    end
+
+    context 'when the gemspec has the given dependency with a different version constraint' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.version = '0.1.0'
+          spec.add_development_dependency 'test_tool', '~> 2.0'
+        end
+      GEMSPEC
+
+      it 'is expected to update only the version constraint' do
+        expect(subject).to eq(<<~EXPECTED_GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = 'my_project'
+            spec.version = '0.1.0'
+            spec.add_development_dependency 'test_tool', '~> 2.1'
+          end
+        EXPECTED_GEMSPEC
+      end
+
+      context 'when the version constraint uses double quotes' do
+        let(:gemspec) { <<~GEMSPEC }
+          Gem::Specification.new do |spec|
+            spec.name = "my_project"
+            spec.version = "0.1.0"
+            spec.add_development_dependency "test_tool", "~> 2.0"
+          end
+        GEMSPEC
+
+        it 'is expected to maintain the type of quote used' do
+          expect(subject).to eq(<<~EXPECTED_GEMSPEC)
+            Gem::Specification.new do |spec|
+              spec.name = "my_project"
+              spec.version = "0.1.0"
+              spec.add_development_dependency "test_tool", "~> 2.1"
+            end
+          EXPECTED_GEMSPEC
+        end
+      end
+    end
+
+    context 'when changing a runtime dependency to a development dependency' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = "my_project"
+          spec.version = "0.1.0"
+          spec.add_dependency "test_tool", "~> 2.0"
+        end
+      GEMSPEC
+
+      context 'when force is false' do
+        it 'is expected to raise an error' do
+          expect { subject }.to raise_error(
+            RuntimeError,
+            'Trying to add a DEVELOPMENT dependency on "test_tool" ' \
+            'which conflicts with the existing RUNTIME dependency. ' \
+            'Pass force: true to update dependencies where the ' \
+            'dependency type is different.'
+          )
+        end
+      end
+
+      context 'when force is true' do
+        let(:force) { true }
+        it 'is expected to update the dependency' do
+          expect(subject).to eq(<<~EXPECTED_GEMSPEC)
+            Gem::Specification.new do |spec|
+              spec.name = "my_project"
+              spec.version = "0.1.0"
+              spec.add_development_dependency "test_tool", "~> 2.1"
+            end
+          EXPECTED_GEMSPEC
+        end
+      end
+    end
+
+    context 'when changing a development dependency to a runtime dependency' do
+      let(:dependency_type) { :runtime }
+
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = "my_project"
+          spec.version = "0.1.0"
+          spec.add_development_dependency "test_tool", "~> 2.0"
+        end
+      GEMSPEC
+
+      context 'when force is false' do
+        it 'is expected to raise an error' do
+          expect { subject }.to raise_error(
+            RuntimeError,
+            'Trying to add a RUNTIME dependency on "test_tool" ' \
+            'which conflicts with the existing DEVELOPMENT dependency. ' \
+            'Pass force: true to update dependencies where the ' \
+            'dependency type is different.'
+          )
+        end
+      end
+    end
+
+    context 'when the gemspec has the given dependency more than once' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = "my_project"
+          spec.version = "0.1.0"
+          spec.add_development_dependency "test_tool", "~> 2.0"
+          spec.add_development_dependency "test_tool", "~> 2.0"
+        end
+      GEMSPEC
+
+      it 'is expected to update all instances of the given dependency' do
+        expect(subject).to eq(<<~EXPECTED_GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = "my_project"
+            spec.version = "0.1.0"
+            spec.add_development_dependency "test_tool", "~> 2.1"
+            spec.add_development_dependency "test_tool", "~> 2.1"
+          end
+        EXPECTED_GEMSPEC
+      end
+    end
+  end
+end

--- a/spec/lib/bundler/gem_bytes/script_executor_spec.rb
+++ b/spec/lib/bundler/gem_bytes/script_executor_spec.rb
@@ -3,6 +3,14 @@
 RSpec.describe Bundler::GemBytes::ScriptExecutor do
   let(:instance) { described_class.new }
 
+  it 'is expected to include Thor actions' do
+    expect(described_class.ancestors).to include(Thor::Actions)
+  end
+
+  it 'is expected to include GemBytes actions' do
+    expect(described_class.ancestors).to include(Bundler::GemBytes::Actions)
+  end
+
   describe '#execute' do
     subject { instance.execute(path_or_uri) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Turnip setup
+#
+require 'turnip/rspec'
+Dir[File.join(__dir__, '**/*_steps.rb')].each { |f| require f }
+
+# RSpec setup
+#
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -12,7 +19,21 @@ RSpec.configure do |config|
   end
 end
 
+# SimpleCov configuration
+#
+require 'simplecov'
+require 'simplecov-lcov'
 require 'simplecov-rspec'
-SimpleCov::RSpec.start
+
+def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+
+if ci_build?
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
+end
+
+SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 
 require 'bundler/gem_bytes'


### PR DESCRIPTION
Added #add_dependency to the Bundler::GemBytes::Actions module which makes it available to call from GemBytes scripts as follows:

```
add_dependency [TYPE], [GEM], [VERSION_CONSTRAINT]
```

where:

* **[TYPE]** must be either `:development` or `:runtime`, 
* **[GEM]** is the name of the gem to add a dependency on and 
* **[VERSION_CONTRAINT]** is the bundler version constraint string (e.g. '~> 1.0', '1.1.2', etc.)

A concrete example:

```
add_dependency :development, "rubocop", "~> 1.6"
```