### PR TITLE
fix: allow dependencies to have multiple version constraints

### DIFF
--- a/lib/bundler/gem_bytes/actions/gemspec.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec.rb
@@ -181,12 +181,12 @@ module Bundler
         #   # Adds (or updates) the following line to the Gem::Specification block:
         #   # spec.add_dependency 'rails', '~> 7.0'
         # @param gem_name [String] the name of the gem to add a dependency on
-        # @param version_constraint [String] the version constraint on the gem
+        # @param version_constraints [Array[String]] one or more version constraints on the gem
         # @param method_name [String] the name of the method to use to add the dependency
         # @return [void]
         #
-        def add_dependency(gem_name, version_constraint, method_name: :add_dependency)
-          new_dependency = Dependency.new(method_name, gem_name, version_constraint)
+        def add_dependency(gem_name, *version_constraints, method_name: :add_dependency)
+          new_dependency = Dependency.new(method_name, gem_name, version_constraints)
           UpsertDependency.new(self, gemspec_block, receiver_name, dependencies).call(new_dependency)
         end
 

--- a/lib/bundler/gem_bytes/actions/gemspec/dependency.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec/dependency.rb
@@ -50,11 +50,11 @@ module Bundler
         #   @return [String]
         #   @api public
         #
-        # @!attribute [r] version_constraint
-        #   The version constraint for the dependency (e.g., '~> 1.0')
+        # @!attribute [r] version_constraints
+        #   The version constraints for the dependency
         #   @example
-        #     dependency.version_constraint #=> "~> 1.68"
-        #   @return [String]
+        #     dependency.version_constraints #=> ["~> 1.68", ">= 1.68.3"]
+        #   @return [Array<String>]
         #   @api public
         #
         # @!method to_a()
@@ -64,8 +64,8 @@ module Bundler
         #   @return [Array]
         #   @api public
         #
-        Dependency = Struct.new(:method_name, :gem_name, :version_constraint) do
-          def to_a = [method_name, gem_name, version_constraint]
+        Dependency = Struct.new(:method_name, :gem_name, :version_constraints) do
+          def to_a = [method_name, gem_name, *version_constraints]
         end
       end
     end

--- a/lib/bundler/gem_bytes/actions/gemspec/upsert_dependency.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec/upsert_dependency.rb
@@ -166,7 +166,7 @@ module Bundler
             # :nocov: supress false reporting of no coverage of multiline string literals on JRuby
             "#{receiver_name}.#{new_method_name(existing_dependency)} " \
               "#{q}#{new_dependency.gem_name}#{q}, " \
-              "#{q}#{new_dependency.version_constraint}#{q}"
+              "#{new_dependency.version_constraints.map { |vc| "#{q}#{vc}#{q}" }.join(', ')}"
             # :nocov:
           end
 

--- a/spec/lib/bundler/gem_bytes/actions/gemspec_spec.rb
+++ b/spec/lib/bundler/gem_bytes/actions/gemspec_spec.rb
@@ -160,6 +160,48 @@ RSpec.describe Bundler::GemBytes::Actions::Gemspec do
       }
     end
 
+    context 'when the gemspec has the given dependency and the new dependency has multiple version constraints' do
+      let(:block) do
+        proc { |_receiver_name, _spec|
+          add_dependency 'example', '~> 2.1', '>= 2.1.4'
+        }
+      end
+
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.add_dependency 'example', '~> 1.0'
+        end
+      GEMSPEC
+
+      it 'is expected to update the dependency with the new version constraints' do
+        expect(subject).to eq(<<~GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = 'my_project'
+            spec.add_dependency 'example', '~> 2.1', '>= 2.1.4'
+          end
+        GEMSPEC
+      end
+    end
+
+    context 'when the gemspec has the given dependency with multiple version constraints' do
+      let(:gemspec) { <<~GEMSPEC }
+        Gem::Specification.new do |spec|
+          spec.name = 'my_project'
+          spec.add_dependency 'example', '~> 1.0', '>= 1.1.2'
+        end
+      GEMSPEC
+
+      it 'is expected to update the dependency with the new version constraints' do
+        expect(subject).to eq(<<~GEMSPEC)
+          Gem::Specification.new do |spec|
+            spec.name = 'my_project'
+            spec.add_dependency 'example', '~> 2.0'
+          end
+        GEMSPEC
+      end
+    end
+
     context 'when the gemspec block is empty' do
       let(:gemspec) { <<~GEMSPEC }
         Gem::Specification.new do |spec|


### PR DESCRIPTION
Currently, a dependency may only have one version constraint:

`add_dependency "example", "~> 2.0"`

Providing multiple constraints like the following would fail:

`add_dependency "example", "~> 2.0", ">= 2.1.4"