### PR TITLE
chore: parse attributes from the gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ chat rooms and mailing lists is expected to follow the [code of
 conduct](https://github.com/main-branch/bundler-gem_bytes/blob/main/CODE_OF_CONDUCT.md).
 
 gemspec path do |spec_var, spec|
+  add_dependency 'example', '~> 1.1'
   add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'
   add_development_dependency "rubocop", "~> 1.68"
 
@@ -240,12 +241,13 @@ gemspec path do |spec_var, spec|
   remove_attr "license"
 
   metadata "homepage_url", "https://github.com/example/"
+
   remove_metadata "wiki_uri"
 
   in_block("if RUBY_PLATFORM != 'java'", "end") do
-    add_development_dependency 'redcarpet', '~> 3.5'
-    add_development_dependency 'yard', '~> 0.9'
-    add_development_dependency 'yardstick', '~> 0.9'
+    development_dependency 'redcarpet', '~> 3.5'
+    development_dependency 'yard', '~> 0.9'
+    development_dependency 'yardstick', '~> 0.9'
   end
 
   code <<~CODE

--- a/lib/bundler/gem_bytes/actions/gemspec/attribute.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec/attribute.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'parser/current'
+require 'rubocop-ast'
+require 'active_support/core_ext/object'
+
+module Bundler
+  module GemBytes
+    module Actions
+      class Gemspec < Parser::TreeRewriter
+        # Holds the components of a attribute: a name and a value
+        #
+        # @api public
+        #
+        # Attributes in the gemspec look like the following:
+        #
+        # ```ruby
+        # Gem::Specification.new do |spec|
+        #   spec.name = 'test'
+        # end
+        # ```
+        #
+        # @!attribute [r] name
+        #   The name of the attribute
+        #   @example
+        #     attribute.name #=> "test"
+        #
+        #   @return [String]
+        #   @api public
+        #
+        # @!attribute [r] value
+        #   The value of the attribute expressed as an AST tree
+        #   @example
+        #     attribute.value.to_sexp #=> 's(:str, "my_description")'
+        #   @return [Parser::AST::Node]
+        #   @api public
+        #
+        # @!method to_a()
+        #   Converts the attribute into an array
+        #   @example
+        #     dependency.to_a #=> ["description", [:str, "my_description"]]
+        #   @return [Array]
+        #   @api public
+        #
+        Attribute = Struct.new(:name, :value) do
+          def to_a = [name, value.to_sexp_array]
+        end
+      end
+    end
+  end
+end

--- a/lib/bundler/gem_bytes/actions/gemspec/attribute_node.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec/attribute_node.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'parser/current'
+require 'rubocop-ast'
+require 'active_support/core_ext/object'
+
+module Bundler
+  module GemBytes
+    module Actions
+      class Gemspec < Parser::TreeRewriter
+        # Maps a dependency declaration to the AST that represents it
+        # @api public
+        #
+        # @!attribute [r] node
+        #   The AST node for the attribute
+        #   @example
+        #     attribute_node.node #=> ...
+        #   @return [Parser::AST::Node]
+        #   @api public
+        #
+        # @!attribute [r] attribute
+        #   The components of the attribute from the AST node
+        #   @example
+        #     attribute_node.attribute.to_a #=> ["description", [:str, "My deescription"]]
+        #   @return [Dependency]
+        #   @api public
+        #
+        AttributeNode = Struct.new(:node, :attribute)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Attributes look like this:

```
spec.name = 'example'
```

After calling Gemspec#call, the Gemspec#attributes attribute will be populated
with an array of AttributeNode objects which each refer to an attribute and a
node. The attribute has attributes name and value. The node is a
Parser::AST::Node object which represents the attribute in the gemspec's AST.