### PR TITLE
Remove Code Climate integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,27 +50,3 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
-
-  coverage:
-    name: Report test coverage to CodeClimate
-
-    needs: [build]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Initialize Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1
-          bundler-cache: true
-
-      - name: Report test coverage
-        uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: 7fd2c226e4e72c37477e999ef826a19cb2dd2fd2e30db8747bbc09bcfd738215
-        with:
-          coverageCommand: bundle exec rake spec
-          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Version](https://badge.fury.io/rb/bundler-gem_bytes.svg)](https://badge.fury.io/
 Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/bundler-gem_bytes/file/CHANGELOG.md)
 [![Build
 Status](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/main-branch/bundler-gem_bytes/actions/workflows/continuous-integration.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2468fc247e5d66fc179f/maintainability)](https://codeclimate.com/github/main-branch/bundler-gem_bytes/maintainability)
-[![Test
-Coverage](https://api.codeclimate.com/v1/badges/2468fc247e5d66fc179f/test_coverage)](https://codeclimate.com/github/main-branch/bundler-gem_bytes/test_coverage)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Slack](https://img.shields.io/badge/slack-main--branch/bundler--gem_bytes-yellow.svg?logo=slack)](https://main-branch.slack.com/archives/C07RKRKTLDT)
@@ -36,15 +33,15 @@ own script**
 
 * [Installation](#installation)
 * [Usage](#usage)
-  * [Example](#example)
-  * [Handling Errors](#handling-errors)
+    * [Example](#example)
+    * [Handling Errors](#handling-errors)
 * [Development](#development)
-  * [How this gem works](#how-this-gem-works)
-  * [Debugging](#debugging)
-  * [Releasing](#releasing)
+    * [How this gem works](#how-this-gem-works)
+    * [Debugging](#debugging)
+    * [Releasing](#releasing)
 * [Contributing](#contributing)
-  * [Commit message guidelines](#commit-message-guidelines)
-  * [Pull request guidelines](#pull-request-guidelines)
+    * [Commit message guidelines](#commit-message-guidelines)
+    * [Pull request guidelines](#pull-request-guidelines)
 * [License](#license)
 * [Code of Conduct](#code-of-conduct)
 


### PR DESCRIPTION
Eliminate Code Climate badges and coverage reporting from the build process to streamline CI configuration.