### PR TITLE
fix: do not trigger build workflows after merging to main or for release PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 
@@ -13,30 +10,27 @@ env:
   # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
   # results from JRuby are complete.
   JRUBY_OPTS: --debug
-  # List lines that are not covered by tests (from SimpleCov::RSpec)
-  LIST_UNCOVERED_LINES: "true"
-
-# Supported platforms / Ruby versions:
-#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
-#  - Windows: MRI (3.1), JRuby (9.4)
 
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
+
+    env:
+      FAIL_ON_LOW_COVERAGE: ${{ matrix.fail_on_low_coverage }}
 
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
-        include:
-          - ruby: "3.1"
-            operating-system: windows-latest
-          - ruby: "jruby-9.4"
-            operating-system: windows-latest
+        fail_on_low_coverage: [true]
 
     steps:
       - name: Checkout

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -9,6 +9,10 @@ jobs:
   commit-lint:
     name: Verify Conventional Commits
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,21 +1,16 @@
 name: Experimental Ruby Builds
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 env:
   # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
   # results from JRuby are complete.
   JRUBY_OPTS: --debug
-  # List lines that are not covered by tests (from SimpleCov::RSpec)
-  LIST_UNCOVERED_LINES: "true"
 
 # Experimental platforms / Ruby versions:
 #  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
-#  - Windows: MRI (head), JRuby (head)
+#  - Windows: MRI (head), JRuby (head), JRuby (9.4)
 
 jobs:
   build:
@@ -24,20 +19,43 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
+    env:
+      FAIL_ON_LOW_COVERAGE: ${{ matrix.fail_on_low_coverage }}
+      GIT_AUTHOR_NAME: Git Author
+      GIT_AUTHOR_EMAIL: git_author@example.com
+      GIT_COMMITTER_NAME: Git Committer
+      GIT_COMMITTER_EMAIL: git_committer@example.com
+
     strategy:
       fail-fast: false
       matrix:
+        fail_on_low_coverage: [true]
         include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+            fail_on_low_coverage: false
           - ruby: head
             operating-system: ubuntu-latest
           - ruby: head
             operating-system: windows-latest
+          - ruby: "truffleruby-24"
+            operating-system: ubuntu-latest
+            fail_on_low_coverage: false
           - ruby: truffleruby-head
             operating-system: ubuntu-latest
+            fail_on_low_coverage: false
+          - ruby: "jruby-9.4"
+            operating-system: ubuntu-latest
+            fail_on_low_coverage: false
+          - ruby: "jruby-9.4"
+            operating-system: windows-latest
+            fail_on_low_coverage: false
           - ruby: jruby-head
             operating-system: ubuntu-latest
+            fail_on_low_coverage: false
           - ruby: jruby-head
             operating-system: windows-latest
+            fail_on_low_coverage: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Since all merges to the main branch must be a fast-forward rebase, CI
builds should not be run when merged to main. They are run via the
pull request before merging.

The continuous_integration workflow should be triggered for pull requests
targeting main.

The experimental_ruby_builds workflow should only be triggered manually via
the GitHub UI.

Move unneeded builds from continuous_integration to experimental_ruby_builds

There is not a good reason to have a specific builds in the
continuous_integration workflow on Windows, or using JRuby or TruffleRuby.