### PR TITLE
build(dependencies): update GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Check Commit Messages

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}

--- a/lib/bundler/gem_bytes/actions/gemspec.rb
+++ b/lib/bundler/gem_bytes/actions/gemspec.rb
@@ -136,7 +136,7 @@ module Bundler
         def on_send(node)
           return unless processing_gemspec_block?
 
-          handle_dependency(node) || handle_attribute(node)
+          handle_dependency?(node) || handle_attribute?(node)
         end
 
         # Removes a dependency from the Gem::Specification block
@@ -204,7 +204,7 @@ module Bundler
         # @param node [Parser::AST::Node] the node to check if it is a dependency
         # @return [Boolean] true if the node is a dependency, false otherwise
         # @api private
-        def handle_dependency(node)
+        def handle_dependency?(node)
           return false unless (match = dependency_pattern.match(node))
 
           dependencies << DependencyNode.new(node, Dependency.new(*match))
@@ -216,7 +216,7 @@ module Bundler
         # @param node [Parser::AST::Node] the node to check if it is an attribute
         # @return [Boolean] true if the node is an attribute, false otherwise
         # @api private
-        def handle_attribute(node)
+        def handle_attribute?(node)
           return false unless (match = attribute_pattern.match(node))
           return false unless match[0].end_with?('=')
 


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflow dependencies to their latest major versions, and fixes RuboCop offenses from new cops.

### Actions updated

- `actions/checkout`: `@v4` → `@v6` (latest: v6.0.2)
- `googleapis/release-please-action`: `@v4` → `@v5` (latest: v5.0.0)

### RuboCop fixes

- Renamed `handle_dependency` → `handle_dependency?` and `handle_attribute` → `handle_attribute?` in `lib/bundler/gem_bytes/actions/gemspec.rb` to satisfy the `Naming/PredicateMethod` cop.